### PR TITLE
135 fix spotify bugs

### DIFF
--- a/atoms/spotify.js
+++ b/atoms/spotify.js
@@ -11,3 +11,13 @@ export const refresh = atom({
   key: 'spotify-refresh',
   default: null,
 });
+
+export const spotifyAuthURL = atom({
+  key: 'spotify-spotifyAuthURL',
+  default: '',
+});
+
+export const roomID = atom({
+  key: 'spotify-roomID',
+  default: '',
+});

--- a/components/Spaces/CallTabs/Music/Player.js
+++ b/components/Spaces/CallTabs/Music/Player.js
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import { isEqual } from 'lodash';
 import SpotifyPlayer from 'react-spotify-web-playback';
 
 import { useSpotify } from './SpotifyProvider';

--- a/components/Spaces/CallTabs/Music/Playlist.js
+++ b/components/Spaces/CallTabs/Music/Playlist.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles((theme) => ({
   thumbnailImage: {
     margin: 'auto',
     height: '112px',
-    width: '112px',
+    width: 'auto',
     objectFit: 'cover',
     objectPosition: '50% 50%',
   },
@@ -25,7 +25,7 @@ const Playlist = ({ playlist, playPlaylist }) => {
   const classes = useStyles();
 
   return (
-    <div className="flex flex-col m-1 cursor-pointer w-28" role="button" onClick={() => playPlaylist(playlist)}>
+    <div className="flex flex-col cursor-pointer" role="button" onClick={() => playPlaylist(playlist)}>
       <img src={image} alt="song thumbnail" className={classes.thumbnailImage} />
       <Typography variant="caption" className={classes.playlistTitle}>
         {title}

--- a/components/Spaces/CallTabs/Music/SpotifyProvider.js
+++ b/components/Spaces/CallTabs/Music/SpotifyProvider.js
@@ -16,13 +16,13 @@ export function useSpotify() {
   return useContext(SpotifyContext);
 }
 
-export const AUTHENTICATION_ENUM = {
+export const ENUM_AUTHENTICATION = {
   LOADING: 'LOADING',
   AUTHENTICATED: 'AUTHENTICATED',
   NOT_AUTHENTICATED: 'NOT_AUTHENTICATED',
 };
 export function SpotifyProvider({ children }) {
-  const [authenticated, setAuthenticated] = useState(AUTHENTICATION_ENUM.LOADING);
+  const [authenticated, setAuthenticated] = useState(ENUM_AUTHENTICATION.LOADING);
   const [accessToken, setAccessToken] = useState('');
   const [user, setUser] = useState(null);
   const [userPlaylists, setUserPlaylists] = useState([]);
@@ -53,12 +53,12 @@ export function SpotifyProvider({ children }) {
       const username = userData.body.id;
       const playlistData = await spotifyApi.getUserPlaylists(username);
       setUser(userData.body);
-      setAuthenticated(AUTHENTICATION_ENUM.AUTHENTICATED);
+      setAuthenticated(ENUM_AUTHENTICATION.AUTHENTICATED);
       const rawPlaylists = playlistData.body.items;
       setUserPlaylists(() => parsePlaylists(rawPlaylists));
     } catch (err) {
       console.debug('Something went wrong fetching your Spotify Information!', err);
-      setAuthenticated(AUTHENTICATION_ENUM.NOT_AUTHENTICATED);
+      setAuthenticated(ENUM_AUTHENTICATION.NOT_AUTHENTICATED);
     }
   };
 
@@ -97,7 +97,7 @@ export function SpotifyProvider({ children }) {
   useEffect(() => {
     const hasToken = getAccessTokenFromCookies();
     if (!hasToken) {
-      setAuthenticated(AUTHENTICATION_ENUM.NOT_AUTHENTICATED);
+      setAuthenticated(ENUM_AUTHENTICATION.NOT_AUTHENTICATED);
       return;
     }
     initUser();

--- a/components/Spaces/CallTabs/Music/SpotifyProvider.js
+++ b/components/Spaces/CallTabs/Music/SpotifyProvider.js
@@ -38,11 +38,12 @@ export function SpotifyProvider({ children }) {
 
   const getAccessTokenFromCookies = () => {
     const spotifySessionJWT = getCookie(document.cookie, 'spotify_session');
-    if (!spotifySessionJWT) return;
+    if (!spotifySessionJWT) return false;
     const spotifySession = jwt.decode(spotifySessionJWT);
-    if (!spotifySession?.accessToken) return;
+    if (!spotifySession?.accessToken) return false;
     setAccessToken(spotifySession.accessToken);
     spotifyApi.setAccessToken(spotifySession.accessToken);
+    return true;
   };
 
   const initUser = async () => {
@@ -94,7 +95,11 @@ export function SpotifyProvider({ children }) {
   };
 
   useEffect(() => {
-    getAccessTokenFromCookies();
+    const hasToken = getAccessTokenFromCookies();
+    if (!hasToken) {
+      setAuthenticated(AUTHENTICATION_ENUM.NOT_AUTHENTICATED);
+      return;
+    }
     initUser();
     initRecommendedPlaylists();
   }, []);

--- a/components/Spaces/CallTabs/Music/SpotifyProvider.js
+++ b/components/Spaces/CallTabs/Music/SpotifyProvider.js
@@ -16,10 +16,10 @@ export function useSpotify() {
   return useContext(SpotifyContext);
 }
 
-const AUTHENTICATION_ENUM = {
+export const AUTHENTICATION_ENUM = {
   LOADING: 'LOADING',
   AUTHENTICATED: 'AUTHENTICATED',
-  UN_AUTHENTICATED: 'UN_AUTHENTICATED',
+  NOT_AUTHENTICATED: 'NOT_AUTHENTICATED',
 };
 export function SpotifyProvider({ children }) {
   const [authenticated, setAuthenticated] = useState(AUTHENTICATION_ENUM.LOADING);
@@ -52,10 +52,12 @@ export function SpotifyProvider({ children }) {
       const username = userData.body.id;
       const playlistData = await spotifyApi.getUserPlaylists(username);
       setUser(userData.body);
+      setAuthenticated(AUTHENTICATION_ENUM.AUTHENTICATED);
       const rawPlaylists = playlistData.body.items;
       setUserPlaylists(() => parsePlaylists(rawPlaylists));
     } catch (err) {
       console.debug('Something went wrong fetching your Spotify Information!', err);
+      setAuthenticated(AUTHENTICATION_ENUM.NOT_AUTHENTICATED);
     }
   };
 
@@ -102,6 +104,7 @@ export function SpotifyProvider({ children }) {
   }, [queue]);
 
   const value = {
+    authenticated,
     getAccessTokenFromCookies,
     spotifyApi,
     accessToken,

--- a/components/Spaces/CallTabs/Music/SpotifyProvider.js
+++ b/components/Spaces/CallTabs/Music/SpotifyProvider.js
@@ -16,7 +16,13 @@ export function useSpotify() {
   return useContext(SpotifyContext);
 }
 
+const AUTHENTICATION_ENUM = {
+  LOADING: 'LOADING',
+  AUTHENTICATED: 'AUTHENTICATED',
+  UN_AUTHENTICATED: 'UN_AUTHENTICATED',
+};
 export function SpotifyProvider({ children }) {
+  const [authenticated, setAuthenticated] = useState(AUTHENTICATION_ENUM.LOADING);
   const [accessToken, setAccessToken] = useState('');
   const [user, setUser] = useState(null);
   const [userPlaylists, setUserPlaylists] = useState([]);

--- a/components/Spaces/CallTabs/Music/SpotifySignUpBlocker.js
+++ b/components/Spaces/CallTabs/Music/SpotifySignUpBlocker.js
@@ -1,20 +1,36 @@
 import Backdrop from '@material-ui/core/Backdrop';
 import Button from '@material-ui/core/Button';
 import { makeStyles } from '@material-ui/core/styles';
+import { useRecoilValue } from 'recoil';
+
+import * as spotifyState from '@/atoms/spotify';
+import { PREFIX } from '@/hooks/useLocalStorage';
 
 const useStyles = makeStyles((theme) => ({
   backdrop: {
+    width: '100%',
+    height: '100%',
+    position: 'relative',
     zIndex: theme.zIndex.drawer + 1,
     color: '#fff',
   },
 }));
 
+export const ROOM_ID = 'ROOM_ID';
+
 const SpotifySignUpBlocker = () => {
   const classes = useStyles();
+  const roomID = useRecoilValue(spotifyState.roomID);
+  const spotifyAuthURL = useRecoilValue(spotifyState.spotifyAuthURL);
+
+  const handleClicked = () => {
+    localStorage.setItem(PREFIX + ROOM_ID, roomID);
+    window.location.replace(spotifyAuthURL);
+  };
 
   return (
     <Backdrop className={classes.backdrop} open>
-      <Button variant="outlined" color="primary">
+      <Button variant="outlined" color="secondary" onClick={handleClicked}>
         Sign in to Spotify
       </Button>
     </Backdrop>

--- a/components/Spaces/CallTabs/Music/SpotifySignUpBlocker.js
+++ b/components/Spaces/CallTabs/Music/SpotifySignUpBlocker.js
@@ -1,10 +1,12 @@
+import { useRouter } from 'next/router';
+import PropTypes from 'prop-types';
 import Backdrop from '@material-ui/core/Backdrop';
 import Button from '@material-ui/core/Button';
+import CircularProgress from '@material-ui/core/CircularProgress';
 import { makeStyles } from '@material-ui/core/styles';
 import { useRecoilValue } from 'recoil';
 
 import * as spotifyState from '@/atoms/spotify';
-import { PREFIX } from '@/hooks/useLocalStorage';
 
 const useStyles = makeStyles((theme) => ({
   backdrop: {
@@ -18,23 +20,32 @@ const useStyles = makeStyles((theme) => ({
 
 export const ROOM_ID = 'ROOM_ID';
 
-const SpotifySignUpBlocker = () => {
+const SpotifySignUpBlocker = ({ loading }) => {
   const classes = useStyles();
   const roomID = useRecoilValue(spotifyState.roomID);
   const spotifyAuthURL = useRecoilValue(spotifyState.spotifyAuthURL);
+  const router = useRouter();
 
   const handleClicked = () => {
-    localStorage.setItem(PREFIX + ROOM_ID, roomID);
-    window.location.replace(spotifyAuthURL);
+    document.cookie = `productify_roomID=${roomID}; path=/`;
+    router.push(spotifyAuthURL);
   };
 
   return (
     <Backdrop className={classes.backdrop} open>
-      <Button variant="outlined" color="secondary" onClick={handleClicked}>
-        Sign in to Spotify
-      </Button>
+      {loading ? (
+        <CircularProgress color="secondary" />
+      ) : (
+        <Button variant="outlined" color="secondary" onClick={handleClicked}>
+          Sign in to Spotify
+        </Button>
+      )}
     </Backdrop>
   );
+};
+
+SpotifySignUpBlocker.propTypes = {
+  loading: PropTypes.bool.isRequired,
 };
 
 export default SpotifySignUpBlocker;

--- a/components/Spaces/CallTabs/Music/SpotifySignUpBlocker.js
+++ b/components/Spaces/CallTabs/Music/SpotifySignUpBlocker.js
@@ -1,0 +1,24 @@
+import Backdrop from '@material-ui/core/Backdrop';
+import Button from '@material-ui/core/Button';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  backdrop: {
+    zIndex: theme.zIndex.drawer + 1,
+    color: '#fff',
+  },
+}));
+
+const SpotifySignUpBlocker = () => {
+  const classes = useStyles();
+
+  return (
+    <Backdrop className={classes.backdrop} open>
+      <Button variant="outlined" color="primary">
+        Sign in to Spotify
+      </Button>
+    </Backdrop>
+  );
+};
+
+export default SpotifySignUpBlocker;

--- a/components/Spaces/CallTabs/Music/Tabs/Home.js
+++ b/components/Spaces/CallTabs/Music/Tabs/Home.js
@@ -12,6 +12,13 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.primary.dark,
     marginBottom: theme.spacing(1),
   },
+  songGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, 112px)',
+    gridGap: '1rem',
+    justifyContent: 'space-around',
+    alignItems: 'flex-start',
+  },
 }));
 
 const SpotifyHome = () => {
@@ -57,7 +64,7 @@ const SpotifyHome = () => {
         <Typography variant="subtitle2" className={classes.heading}>
           {name}
         </Typography>
-        <Grid container alignItems="flex-start">
+        <Grid container className={classes.songGrid}>
           {playlistObj.map((playlist) => (
             <Playlist key={playlist.id} playlist={playlist} playPlaylist={playPlaylist} />
           ))}

--- a/components/Spaces/CallTabs/Music/index.js
+++ b/components/Spaces/CallTabs/Music/index.js
@@ -6,6 +6,7 @@ import axios from 'axios';
 import { useRecoilState } from 'recoil';
 import { differenceInMilliseconds, addMilliseconds } from 'date-fns';
 import { TabList, Tab, Tabs, TabPanel } from 'react-tabs';
+import CircularProgress from '@material-ui/core/CircularProgress';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
@@ -13,7 +14,8 @@ import { makeStyles } from '@material-ui/core/styles';
 import renderComponent from 'utils/renderComponent';
 import getCookie from 'utils/getCookie';
 import * as spotifyState from 'atoms/spotify';
-import { useSpotify } from './SpotifyProvider';
+import { useSpotify, AUTHENTICATION_ENUM } from './SpotifyProvider';
+import SpotifySignUpBlocker from './SpotifySignUpBlocker';
 import Player from './Player';
 import HomeTab from './Tabs/Home';
 import SearchSongsTab from './Tabs/SearchSongs';
@@ -53,7 +55,7 @@ const useStyles = makeStyles((theme) => ({
 
 const Music = ({ tabs }) => {
   const classes = useStyles();
-  const { getAccessTokenFromCookies } = useSpotify();
+  const { getAccessTokenFromCookies, authenticated } = useSpotify();
   const [tabIndex, setTabIndex] = useState(0);
   const [spotifyRefresh, setSpotifyRefresh] = useRecoilState(spotifyState.refresh);
 
@@ -87,6 +89,18 @@ const Music = ({ tabs }) => {
 
     return () => clearTimeout(timeout);
   }, [spotifyRefresh]);
+
+  if (authenticated === AUTHENTICATION_ENUM.LOADING) {
+    return (
+      <div className="w-full h-full grid place-items-center">
+        <CircularProgress />
+      </div>
+    );
+  }
+
+  if (authenticated === AUTHENTICATION_ENUM.NOT_AUTHENTICATED) {
+    return <SpotifySignUpBlocker />;
+  }
 
   return (
     <Tabs selectedIndex={tabIndex} onSelect={() => null} className={classes.tabContainer}>

--- a/components/Spaces/CallTabs/Music/index.js
+++ b/components/Spaces/CallTabs/Music/index.js
@@ -6,7 +6,6 @@ import axios from 'axios';
 import { useRecoilState } from 'recoil';
 import { differenceInMilliseconds, addMilliseconds } from 'date-fns';
 import { TabList, Tab, Tabs, TabPanel } from 'react-tabs';
-import CircularProgress from '@material-ui/core/CircularProgress';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
@@ -14,7 +13,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import renderComponent from 'utils/renderComponent';
 import getCookie from 'utils/getCookie';
 import * as spotifyState from 'atoms/spotify';
-import { useSpotify, AUTHENTICATION_ENUM } from './SpotifyProvider';
+import { useSpotify, ENUM_AUTHENTICATION } from './SpotifyProvider';
 import SpotifySignUpBlocker from './SpotifySignUpBlocker';
 import Player from './Player';
 import HomeTab from './Tabs/Home';
@@ -89,8 +88,8 @@ const Music = ({ tabs }) => {
     return () => clearTimeout(timeout);
   }, [spotifyRefresh]);
 
-  if (authenticated !== AUTHENTICATION_ENUM.AUTHENTICATED) {
-    return <SpotifySignUpBlocker loading={authenticated === AUTHENTICATION_ENUM.LOADING} />;
+  if (authenticated !== ENUM_AUTHENTICATION.AUTHENTICATED) {
+    return <SpotifySignUpBlocker loading={authenticated === ENUM_AUTHENTICATION.LOADING} />;
   }
 
   return (

--- a/components/Spaces/CallTabs/Music/index.js
+++ b/components/Spaces/CallTabs/Music/index.js
@@ -64,8 +64,7 @@ const Music = ({ tabs }) => {
     if (!spotifySessionJWT) return;
     const spotifySession = jwt.decode(spotifySessionJWT);
     if (!spotifySession) return;
-    // let timeoutDuration = spotifySession?.expiresIn * 1000 ?? 3600 * 1000; // onehour in milliseconds
-    let timeoutDuration = 100;
+    let timeoutDuration = 100; // set to 100 for instance refresh if recoil state is not set
     if (spotifyRefresh?.refreshDate) {
       const curDate = new Date();
       const timeToRefresh = differenceInMilliseconds(spotifyRefresh?.refreshDate, curDate) ?? 3600 * 1000;

--- a/components/Spaces/CallTabs/Music/index.js
+++ b/components/Spaces/CallTabs/Music/index.js
@@ -90,16 +90,8 @@ const Music = ({ tabs }) => {
     return () => clearTimeout(timeout);
   }, [spotifyRefresh]);
 
-  if (authenticated === AUTHENTICATION_ENUM.LOADING) {
-    return (
-      <div className="w-full h-full grid place-items-center">
-        <CircularProgress />
-      </div>
-    );
-  }
-
-  if (authenticated === AUTHENTICATION_ENUM.NOT_AUTHENTICATED) {
-    return <SpotifySignUpBlocker />;
+  if (authenticated !== AUTHENTICATION_ENUM.AUTHENTICATED) {
+    return <SpotifySignUpBlocker loading={authenticated === AUTHENTICATION_ENUM.LOADING} />;
   }
 
   return (

--- a/components/Spaces/CallTabs/People.js
+++ b/components/Spaces/CallTabs/People.js
@@ -1,29 +1,43 @@
 import { useTranslation } from 'next-i18next';
+import { uniqueId } from 'lodash';
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
-import { Button, Grid, Paper, Dialog, Typography, IconButton } from '@material-ui/core';
-import { Assignment, Mic, MicOff, Videocam, VideocamOff } from '@material-ui/icons';
+import { Button, Grid, Dialog, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import { Assignment } from '@material-ui/icons';
+
+const useStyles = makeStyles(() => ({
+  paper: {
+    borderRadius: '0.375rem',
+  },
+}));
 
 const People = ({ participants, username }) => {
   const { t } = useTranslation();
+  const classes = useStyles();
   const router = useRouter();
   const roomID = router.query;
   const [modalOpen, setModalOpen] = useState(false);
 
   return (
-    <>
+    <div className="p-2">
       {t('LABEL_PEOPLE')}
-      <Button variant="contained" color="primary" fullWidth onClick={() => setModalOpen(true)}>
+      <Button variant="contained" color="primary" fullWidth className="mt-1 mb-2" onClick={() => setModalOpen(true)}>
         {t('LABEL_INVITE')}
       </Button>
       {participants.map((p) => (
-        <p key={p}>
-          {p} {username == p ? '(You)' : ''}
+        <p key={uniqueId(p)}>
+          {p} {username == p && '(You)'}
         </p>
       ))}
-      <Dialog open={modalOpen} onClose={() => setModalOpen(false)} fullWidth maxWidth="lg">
+      <Dialog
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        classes={{ paper: classes.paper }}
+        fullWidth
+        maxWidth="md">
         <Grid className="p-5 flex flex-col align-items-center justify-items-center">
           <Typography
             variant="h6"
@@ -39,7 +53,7 @@ const People = ({ participants, username }) => {
           </CopyToClipboard>
         </Grid>
       </Dialog>
-    </>
+    </div>
   );
 };
 

--- a/hooks/useLocalStorage.js
+++ b/hooks/useLocalStorage.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 
-const PREFIX = 'Productify: ';
+export const PREFIX = 'Productify: ';
 
 const useLocalStorage = (key, initialValue) => {
   const prefixedKey = PREFIX + key;

--- a/pages/room/[...id].js
+++ b/pages/room/[...id].js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';
 import io from 'socket.io-client';
 import Peer from 'simple-peer';
+import addMilliseconds from 'date-fns/addMilliseconds';
 import { getSession } from 'next-auth/client';
 import { uniqueNamesGenerator, colors, animals } from 'unique-names-generator';
 import { intersection } from 'lodash';
@@ -38,7 +39,7 @@ PeerVideo.propTypes = {
   username: PropTypes.string.isRequired,
 };
 
-const Room = ({ roomID, spotifyAuthURL }) => {
+const Room = ({ roomID, spotifyAuthURL, spotifyData }) => {
   const router = useRouter();
   const socketRef = useRef();
   const userVideo = useRef();
@@ -51,6 +52,7 @@ const Room = ({ roomID, spotifyAuthURL }) => {
   const [participants, setParticipants] = useState([]);
   const setRoomID = useSetRecoilState(spotifyState.roomID);
   const setSpotifyAuthURL = useSetRecoilState(spotifyState.spotifyAuthURL);
+  const setSpotifyRefresh = useSetRecoilState(spotifyState.refresh);
 
   const initRoom = async () => {
     const userSession = await getSession();
@@ -174,10 +176,24 @@ const Room = ({ roomID, spotifyAuthURL }) => {
     });
   };
 
-  useEffect(() => {
-    initRoom();
+  const initRecoilState = () => {
     setRoomID(roomID);
     setSpotifyAuthURL(spotifyAuthURL);
+    if (spotifyData) {
+      // redirected back to room and user clicked signed into Spotify in call tab.
+      const expiresIn = spotifyData.expiresIn * 1000;
+      const date = new Date();
+      const expireDate = addMilliseconds(date, expiresIn);
+      const refreshDate = addMilliseconds(date, expiresIn / 4);
+      setSpotifyRefresh({ expiresIn, expireDate, refreshDate });
+      console.debug('Successfully authenticated with shopify:', spotifyData);
+      router.replace('/room/[...id]', `/room/${roomID}`);
+    }
+  };
+
+  useEffect(() => {
+    initRoom();
+    initRecoilState();
   }, []);
 
   const createPeer = (userToSignal, username, callerID, stream) => {
@@ -271,16 +287,27 @@ const Room = ({ roomID, spotifyAuthURL }) => {
 Room.propTypes = {
   roomID: PropTypes.string.isRequired,
   spotifyAuthURL: PropTypes.string.isRequired,
+  spotifyData: PropTypes.object,
 };
 
 export default Room;
 
-export async function getServerSideProps({ locale, params }) {
+export async function getServerSideProps({ locale, params, query }) {
+  let spotifyData = null;
+  if (query && query.data) {
+    try {
+      spotifyData = JSON.parse(query.data);
+    } catch (err) {
+      console.debug('Error occured while trying to parse spotify data from url query:', err);
+    }
+  }
+
   return {
     props: {
       roomID: params.id[0],
       spotifyAuthURL: `https://accounts.spotify.com/authorize?client_id=${process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID}&response_type=code&redirect_uri=${process.env.SPOTIFY_REDIRECT_URI}&scope=streaming%20user-read-email%20user-read-private%20user-library-read%20user-library-modify%20user-read-playback-state%20user-modify-playback-state`,
       ...(await serverSideTranslations(locale, ['common'])),
+      spotifyData,
     },
   };
 }

--- a/pages/room/[...id].js
+++ b/pages/room/[...id].js
@@ -187,6 +187,7 @@ const Room = ({ roomID, spotifyAuthURL, spotifyData }) => {
       const refreshDate = addMilliseconds(date, expiresIn / 4);
       setSpotifyRefresh({ expiresIn, expireDate, refreshDate });
       console.debug('Successfully authenticated with shopify:', spotifyData);
+      // replaces url query to prevent user from copying/pasting space url to friends with unnecessary data
       router.replace('/room/[...id]', `/room/${roomID}`);
     }
   };

--- a/pages/room/index.js
+++ b/pages/room/index.js
@@ -1,8 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import axios from 'axios';
-import addMilliseconds from 'date-fns/addMilliseconds';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { v1 as uuid } from 'uuid';
 import { useRouter } from 'next/router';
 import { getSession } from 'next-auth/client';
@@ -13,7 +12,6 @@ import { useQuery, gql } from '@apollo/client';
 
 import { initializeApollo } from '@/utils/apollo/client';
 import * as clientState from 'atoms/client';
-import * as spotifyState from 'atoms/spotify';
 
 const GET_USERS = gql`
   query ($usersName: String, $usersEmail: String) {
@@ -23,31 +21,12 @@ const GET_USERS = gql`
   }
 `;
 
-const CreateRoom = ({ spotifyAuthURL, spotifyCode, newSession }) => {
+const CreateRoom = ({ newSession }) => {
   const { t } = useTranslation();
   const router = useRouter();
   const [roomID, setRoomID] = useState('');
   const [roomIsLoading, setRoomIsLoading] = useState(false);
-  const [client, setClient] = useRecoilState(clientState.client);
-  const setSpotifyRefresh = useSetRecoilState(spotifyState.refresh);
-
-  useEffect(() => {
-    if (spotifyCode) {
-      axios
-        .post('/api/spotify/login', { code: spotifyCode })
-        .then((res) => {
-          console.debug(res);
-          const expiresIn = res.data.data.expiresIn * 1000;
-          const date = new Date();
-          const expireDate = addMilliseconds(date, expiresIn);
-          const refreshDate = addMilliseconds(date, expiresIn / 4);
-          setSpotifyRefresh({ expiresIn, expireDate, refreshDate });
-          console.debug('Successfully authenticated with shopify:', res.data);
-        })
-        .catch((err) => console.debug(err))
-        .finally(() => router.push('/room'));
-    }
-  }, [spotifyCode]);
+  const setClient = useSetRecoilState(clientState.client);
 
   const createNewSpace = async () => {
     setRoomIsLoading(true);
@@ -72,7 +51,7 @@ const CreateRoom = ({ spotifyAuthURL, spotifyCode, newSession }) => {
 
   return (
     <div className="h-screen w-screen grid place-items-center">
-      <Paper className="w-80">
+      <Paper className="w-96 p-4">
         <Typography component="h1" variant="h5">
           {t('LABEL_JOIN_A_SPACE')}
         </Typography>
@@ -95,15 +74,12 @@ const CreateRoom = ({ spotifyAuthURL, spotifyCode, newSession }) => {
           {roomIsLoading && <CircularProgress />}
         </div>
       </Paper>
-      <Button className="mt-2" href={spotifyAuthURL}>
-        {t('LABEL_LOGIN_TO_SPOTIFY')}
-      </Button>
     </div>
   );
 };
 
 export const getServerSideProps = async (context) => {
-  const { query, locale } = context;
+  const { locale } = context;
   const session = await getSession(context);
   const { name, email } = session.user;
 
@@ -122,8 +98,6 @@ export const getServerSideProps = async (context) => {
 
   return {
     props: {
-      spotifyAuthURL: `https://accounts.spotify.com/authorize?client_id=${process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID}&response_type=code&redirect_uri=${process.env.SPOTIFY_REDIRECT_URI}&scope=streaming%20user-read-email%20user-read-private%20user-library-read%20user-library-modify%20user-read-playback-state%20user-modify-playback-state`,
-      spotifyCode: query?.code ?? '',
       newSession: JSON.parse(JSON.stringify(newSession)),
       ...(await serverSideTranslations(locale, ['common'])),
       initialApolloState: apolloClient.cache.extract(),
@@ -132,8 +106,6 @@ export const getServerSideProps = async (context) => {
 };
 
 CreateRoom.propTypes = {
-  spotifyAuthURL: PropTypes.string.isRequired,
-  spotifyCode: PropTypes.string.isRequired,
   newSession: PropTypes.object.isRequired,
 };
 

--- a/utils/spotify/getClosestImageSize.js
+++ b/utils/spotify/getClosestImageSize.js
@@ -1,7 +1,9 @@
-const getClosestImageSize = (images, size) =>
-  images.reduce((closest, image) => {
+const getClosestImageSize = (images, size) => {
+  if (!images) return {};
+  return images.reduce((closest, image) => {
     if (Math.abs(image.height - size) < Math.abs(closest.height - size)) return image;
     return closest;
   }, images[0]);
+};
 
 export default getClosestImageSize;

--- a/utils/spotify/parsePlaylists.js
+++ b/utils/spotify/parsePlaylists.js
@@ -9,7 +9,7 @@ const parsePlaylists = (rawPlaylists) => {
       title: playlist.name,
       uri: playlist.uri,
       trackURL: playlist.tracks.href,
-      image: bestImage.url,
+      image: bestImage?.url,
     };
   });
   return parsedPlaylists;

--- a/utils/spotify/parseTracks.js
+++ b/utils/spotify/parseTracks.js
@@ -2,14 +2,14 @@ import getClosestImageSize from './getClosestImageSize';
 
 const parseTracks = (tracks) => {
   const parsedTracks = tracks.map((track) => {
-    const smallestAlbumImage = getClosestImageSize(track.album.images, 64);
+    const smallestAlbumImage = getClosestImageSize(track?.album?.images, 64);
     const artists = track.artists.map((artist) => artist.name);
 
     return {
       artist: artists.join(', '),
       title: track.name,
       uri: track.uri,
-      albumUrl: smallestAlbumImage.url,
+      albumUrl: smallestAlbumImage?.url,
     };
   });
   return parsedTracks;


### PR DESCRIPTION
refactored shopify logic to enable signup within the space instead of outside the space. closes #135 
* added new loading/authenticated/unauthenticated enums
* calls spoitfyAuthURL to authenticate user
* handles backend logic at /api/spotify/login
* sets cookie in res header + additional data in query params
* sets appropriate recoil state client side
* window location replace to remove query url
![image](https://user-images.githubusercontent.com/65472533/130347043-118ff6ba-d2e7-41fe-9e12-1e67a2855d2a.png)
- cleaned up some ui issues in the call tabs.

let me know if you think I should add documentation for certain parts of the pr.